### PR TITLE
[sca/otbn] Split loading of OTBN IMEM and DMEM

### DIFF
--- a/sw/device/sca/ecc256_keygen_serial.c
+++ b/sw/device/sca/ecc256_keygen_serial.c
@@ -123,8 +123,6 @@ static void ecc256_set_seed(const uint8_t *seed, size_t seed_len) {
  */
 static void p256_run_keygen(uint32_t mode, const uint32_t *seed,
                             const uint32_t *mask) {
-  SS_CHECK(otbn_load_app(kOtbnAppP256KeyFromSeed) == kOtbnErrorOk);
-
   // Write mode.
   SS_CHECK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode) ==
            kOtbnErrorOk);
@@ -224,11 +222,10 @@ static void ecc256_ecdsa_secret_keygen(const uint8_t *mask, size_t mask_len) {
   uint32_t ecc256_d1[kEcc256SeedNumWords];
   p256_ecdsa_gen_secret_key(ecc256_seed, ecc256_mask, ecc256_d0, ecc256_d1);
 
-  simple_serial_send_packet('r', (unsigned char *) ecc256_d0, kEcc256SeedNumBytes);
-  simple_serial_send_packet('r', (unsigned char *) ecc256_d1, kEcc256SeedNumBytes);
-
-  SS_CHECK(otbn_dmem_sec_wipe() == kOtbnErrorOk);
-  SS_CHECK(otbn_imem_sec_wipe() == kOtbnErrorOk);
+  simple_serial_send_packet('r', (unsigned char *)ecc256_d0,
+                            kEcc256SeedNumBytes);
+  simple_serial_send_packet('r', (unsigned char *)ecc256_d1,
+                            kEcc256SeedNumBytes);
 }
 
 /**
@@ -268,9 +265,6 @@ static void ecc256_ecdsa_gen_keypair(const uint8_t *mask, size_t mask_len) {
                             kEcc256CoordNumBytes);
   simple_serial_send_packet('r', (unsigned char *)ecc256_y,
                             kEcc256CoordNumBytes);
-
-  SS_CHECK(otbn_dmem_sec_wipe() == kOtbnErrorOk);
-  SS_CHECK(otbn_imem_sec_wipe() == kOtbnErrorOk);
 }
 
 /**
@@ -294,6 +288,9 @@ static void simple_serial_main(void) {
            kSimpleSerialOk);
   SS_CHECK(simple_serial_register_handler('x', ecc256_set_seed) ==
            kSimpleSerialOk);
+
+  LOG_INFO("Load p256 keygen from seed app into OTBN");
+  SS_CHECK(otbn_load_app(kOtbnAppP256KeyFromSeed) == kOtbnErrorOk);
 
   LOG_INFO("Starting simple serial packet handling.");
   while (true) {


### PR DESCRIPTION
I edited the ecc256 keygen serial file to split loading of OTBN IMEM and DMEM, as discussed in the SCA WG meeting. This speeds up trace capture by ca. 10%.